### PR TITLE
Changed the logic for getting a cluster cleader 

### DIFF
--- a/deker_server_adapters/cluster_config.py
+++ b/deker_server_adapters/cluster_config.py
@@ -58,21 +58,21 @@ class ClusterConfig:
         """
         leader_id = cluster_config_dict["leader_id"]
 
-        def _process_nodes(nodes: List[dict]) -> List[Node]:
+        def process_nodes(nodes: List[dict]) -> List[Node]:
             node_list = [Node(**node_dict) for node_dict in nodes]
             node_list.sort(key=lambda x: str(x))
             return node_list
 
         # cluster always returns all current RAFT nodes, thus we don't need to check target config to know the leader
         # we won't need RAFT cluster config after getting the leader
-        raft_nodes = _process_nodes(cluster_config_dict["raft"], None)
+        raft_nodes = process_nodes(cluster_config_dict["raft"])
         leader = next((node for node in raft_nodes if node.id == leader_id), None)
 
         if not leader:
             raise DekerClusterError(None, "No leader has been found")
 
-        current = _process_nodes(cluster_config_dict["current"])
-        target = _process_nodes(cluster_config_dict["target"]) if "target" in cluster_config_dict else None
+        current = process_nodes(cluster_config_dict["current"])
+        target = process_nodes(cluster_config_dict["target"]) if "target" in cluster_config_dict else None
 
         return cls(mode=cluster_config_dict["mode"], leader=leader, current=current, target=target)
 

--- a/tests/plugins/cluster.py
+++ b/tests/plugins/cluster.py
@@ -52,6 +52,7 @@ def mocked_ping(nodes: List[Dict]) -> Dict:
         "this_id": "8381202B-8C95-487A-B9B5-0B527056804E",
         "leader_id": "8381202B-8C95-487A-B9B5-0B527056804E",
         "current": nodes,
+        "raft": nodes
     }
 
 

--- a/tests/test_cases/test_cluster/test_httpx_client.py
+++ b/tests/test_cases/test_cluster/test_httpx_client.py
@@ -21,7 +21,15 @@ def test_new_cluster_config_is_applied_after_non_leader_error(
                 "host": "newhost.owm.io",
                 "port": 80,
                 "protocol": "http",
-            },
+            }
+        ],
+        "raft": [
+            {
+                "id": "8381202B-8C95-487A-B9B5-0B527056804A",
+                "host": "newhost.owm.io",
+                "port": 80,
+                "protocol": "http",
+            }
         ],
     }
     # Error


### PR DESCRIPTION
The cluster returns "raft" nodes on '/ping' - adapters should always look into "raft" nodes to find the leader